### PR TITLE
Change default sequence number for client to 1

### DIFF
--- a/smpplib/client.py
+++ b/smpplib/client.py
@@ -43,7 +43,7 @@ class Client(object):
     port = None
     vendor = None
     _socket = None
-    sequence = 0
+    sequence = 1
 
     def __init__(self, host, port, timeout=5):
         """Initialize"""


### PR DESCRIPTION
Openbsc refuses sequence number 0. The default implementation of the client can start with 1 without any
trouble.
