### PR TITLE
Follow up to PR #70, fix Python 2.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+import io
+
 from setuptools import find_packages, setup
 
 setup(
@@ -5,7 +7,7 @@ setup(
     version='1.1',
     url='https://github.com/podshumok/python-smpplib',
     description='SMPP library for python',
-    long_description=open('README.md', 'rt', encoding='utf-8').read(),
+    long_description=io.open('README.md', 'rt', encoding='utf-8').read(),
     long_description_content_type='text/markdown',
     packages=find_packages(),
     install_requires=['six'],


### PR DESCRIPTION
Follow up to https://github.com/python-smpplib/python-smpplib/pull/70 because `encoding` is missing in Python 2.x.