### PR TITLE
Raise an error if `message_payload` is used together with `short_message`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Fix integers converted to strings
 * Fix integer pack format for `size=4`, closes #51
 * Fix typos in `SMPP_INT_NOTIFICATION_*` constants
+* Raise an error if `message_payload` is used together with `short_message`
 
 ### `1.0.3`
 

--- a/smpplib/command.py
+++ b/smpplib/command.py
@@ -702,9 +702,9 @@ class SubmitSM(Command):
         """Prepare to generate binary data"""
 
         if self.short_message:
+            if getattr(self, 'message_payload', None):
+                raise ValueError('`message_payload` can not be used with `short_message`')
             self.sm_length = len(self.short_message)
-            if hasattr(self, 'message_payload'):
-                delattr(self, 'message_payload')
         else:
             self.sm_length = 0
 


### PR DESCRIPTION
Explicit is better than implicit. If both fields are present, `short_message` is silently set to empty. This makes debugging more difficult.