### PR TITLE
fix: don't use % operator in logging

### DIFF
--- a/smpplib/client.py
+++ b/smpplib/client.py
@@ -89,7 +89,7 @@ class Client(object):
 
     def __del__(self):
         if self._socket is not None:
-            logger.warning('%s was not closed' % self)
+            logger.warning('%s was not closed', self)
 
     @property
     def sequence(self):
@@ -116,7 +116,7 @@ class Client(object):
         logger.info('Disconnecting...')
 
         if self.state != consts.SMPP_CLIENT_STATE_OPEN:
-            logger.warning('%s is disconnecting in the bound state' % self)
+            logger.warning('%s is disconnecting in the bound state', self)
         if self._socket is not None:
             self._socket.close()
             self._socket = None


### PR DESCRIPTION
log aggregation tools(like sentry) use unformatted [msg](https://docs.python.org/3/library/logging.html#logrecord-attributes) to aggregate logs.
we can rely on python `logging` module to do `msg % attrs` in this case and we will have better representation of errors in sentry.