### PR TITLE
Function to parse short_message from deliver_sm

### DIFF
--- a/smpplib/pdu.py
+++ b/smpplib/pdu.py
@@ -22,6 +22,7 @@
 
 """PDU module"""
 
+import re
 import struct
 
 from smpplib import command_codes, consts
@@ -48,6 +49,7 @@ class PDU(object):
     command = None
     status = None
     _sequence = None
+    dlr_regex = None
 
     def __init__(self, client=default_client(), **kwargs):
         """Singleton dummy client will be used if omitted"""
@@ -103,6 +105,22 @@ class PDU(object):
             return "Description for status 0x%x not found!" % status
 
         return desc
+
+    @staticmethod
+    def set_delivey_receipt_regex(regex):
+        """To replace the regex used if SMSC uses a different format"""
+        PDU.dlr_regex = re.compile(regex, re.IGNORECASE)
+
+    def parse_deliver_receipt(self):
+        """Parses the short_message property to retrieve deliver_sm infos"""
+
+        if self.command != 'deliver_sm':
+            raise ValueError("Invalid PDU command: %s", self.command)
+
+        if PDU.dlr_regex is None:
+            PDU.dlr_regex = re.compile(rb'^id:(?P<id>\S+)\s+sub:(?P<sub>\S+)\s+dlvrd:(?P<dlvrd>\S+)\s+submit date:(?P<submit_date>\S+)\s+done date:(?P<done_date>\S+)\s+stat:(?P<stat>\S+)\s+err:(?P<err>\S+)\s+Text:(?P<text>.*)$', re.IGNORECASE)
+
+        return PDU.dlr_regex.match(self.short_message).groupdict()
 
     def parse(self, data):
         """Parse raw PDU"""


### PR DESCRIPTION
Not sure if needed ot if correctly implemented but I've added a function to parse the `short_message` property of pdus from `deliver_sm` commands since not all vendors fill in optional parameters like `receipted_message_id`.

Example:
```python
# Inside the message_received_handler
pdu.parse_deliver_receipt()
```
This returns a dict like this one:
```
{
    'dlvrd': b'000',
    'done_date': b'1907311208',
    'err': b'001',
    'id': b'6C7C7DE28BB3E961947700000000FE37',
    'stat': b'UNDELIV',
    'sub': b'001',
    'submit_date': b'1907311208',
    'text': b'Ceci est un tet.'
}
```

Since it depends on a regex and all vendor surely don't implement the receipt the same way (according to the specs: The format for this Delivery Receipt
message is SMSC vendor specific but following is a typical example of Delivery Receipt report.) I've added a way to set the regex manually:
```python
smpp.pdu.set_delivey_receipt_regex(rb'myawesomeregex')
```
Note that the regex must be bytes.