### PR TITLE
Fix not allowing unknown optional parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ logging.basicConfig(level='DEBUG')
 # Two parts, UCS2, SMS with UDH
 parts, encoding_flag, msg_type_flag = smpplib.gsm.make_parts(u'Привет мир!\n'*10)
 
-client = smpplib.client.Client('example.com', SOMEPORTNUMBER)
+client = smpplib.client.Client('example.com', SOMEPORTNUMBER, allow_unknown_opt_params=True)
 
 # Print when obtain message_id
 client.set_message_sent_handler(

--- a/smpplib/client.py
+++ b/smpplib/client.py
@@ -27,6 +27,7 @@ import logging
 import select
 import socket
 import struct
+import warnings
 
 from smpplib import consts, exceptions, smpp
 
@@ -71,17 +72,26 @@ class Client(object):
         sequence_generator=None,
         logger_name=None,
         ssl_context=None,
-        allow_unknown_opt_params=False,
+        allow_unknown_opt_params=None,
     ):
         self.host = host
         self.port = int(port)
         self._ssl_context = ssl_context
-        self.allow_unknown_opt_params = allow_unknown_opt_params
         self.timeout = timeout
         self.logger = logging.getLogger(logger_name or 'smpp.Client.{}'.format(id(self)))
         if sequence_generator is None:
             sequence_generator = SimpleSequenceGenerator()
         self.sequence_generator = sequence_generator
+
+        if allow_unknown_opt_params is None:
+            warnings.warn(
+                "Unknown optional parameters during PDU parsing will stop causing an exception in a future smpplib version (in order to comply with the SMPP spec). To switch behaviour now set allow_unknown_opt_params to True.",
+                DeprecationWarning
+            )
+            self.allow_unknown_opt_params = False
+        else:
+            self.allow_unknown_opt_params = allow_unknown_opt_params
+
 
         self._socket = self._create_socket()
 

--- a/smpplib/client.py
+++ b/smpplib/client.py
@@ -63,10 +63,20 @@ class Client(object):
     _ssl_context = None
     sequence_generator = None
 
-    def __init__(self, host, port, timeout=5, sequence_generator=None, logger_name=None, ssl_context=None):
+    def __init__(
+        self,
+        host,
+        port,
+        timeout=5,
+        sequence_generator=None,
+        logger_name=None,
+        ssl_context=None,
+        allow_unknown_opt_params=False
+    ):
         self.host = host
         self.port = int(port)
         self._ssl_context = ssl_context
+        self.allow_unknown_opt_params = allow_unknown_opt_params
         self.timeout = timeout
         self.logger = logging.getLogger(logger_name or 'smpp.Client.{}'.format(id(self)))
         if sequence_generator is None:
@@ -233,7 +243,11 @@ class Client(object):
 
         self.logger.debug('<<%s (%d bytes)', binascii.b2a_hex(raw_pdu), len(raw_pdu))
 
-        pdu = smpp.parse_pdu(raw_pdu, client=self)
+        pdu = smpp.parse_pdu(
+            raw_pdu,
+            client=self,
+            allow_unknown_opt_params=self.allow_unknown_opt_params
+        )
 
         self.logger.debug('Read %s PDU', pdu.command)
 

--- a/smpplib/client.py
+++ b/smpplib/client.py
@@ -125,7 +125,7 @@ class Client(object):
         if self._ssl_context is None:
             return raw_socket
 
-        return ssl_context.wrap_socket(raw_socket)
+        return self._ssl_context.wrap_socket(raw_socket)
 
     def connect(self):
         """Connect to SMSC"""

--- a/smpplib/client.py
+++ b/smpplib/client.py
@@ -85,8 +85,11 @@ class Client(object):
 
         if allow_unknown_opt_params is None:
             warnings.warn(
-                "Unknown optional parameters during PDU parsing will stop causing an exception in a future smpplib version (in order to comply with the SMPP spec). To switch behaviour now set allow_unknown_opt_params to True.",
-                DeprecationWarning
+                "Unknown optional parameters during PDU parsing will stop "
+                "causing an exception in a future smpplib version "
+                "(in order to comply with the SMPP spec). To switch behavior "
+                "now set allow_unknown_opt_params to True.",
+                DeprecationWarning,
             )
             self.allow_unknown_opt_params = False
         else:

--- a/smpplib/client.py
+++ b/smpplib/client.py
@@ -71,7 +71,7 @@ class Client(object):
         sequence_generator=None,
         logger_name=None,
         ssl_context=None,
-        allow_unknown_opt_params=False
+        allow_unknown_opt_params=False,
     ):
         self.host = host
         self.port = int(port)
@@ -246,7 +246,7 @@ class Client(object):
         pdu = smpp.parse_pdu(
             raw_pdu,
             client=self,
-            allow_unknown_opt_params=self.allow_unknown_opt_params
+            allow_unknown_opt_params=self.allow_unknown_opt_params,
         )
 
         self.logger.debug('Read %s PDU', pdu.command)

--- a/smpplib/command.py
+++ b/smpplib/command.py
@@ -336,11 +336,10 @@ class Command(pdu.PDU):
                 field = get_optional_name(type_code)
             except exceptions.UnknownCommandError as e:
                 if self.allow_unknown_opt_params:
-                    logger.warning("Unknown optional parameter type 0x%x, skipping" % type_code)
+                    logger.warning("Unknown optional parameter type 0x%x, skipping", type_code)
                     pos += length
                     continue
-                else:
-                    raise
+                raise
 
             param = self.params[field]
             if param.type is int:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,12 @@
+import warnings
+
+from smpplib.client import Client
+
+
+def test_client_construction_allow_unknown_opt_params_warning():
+    with warnings.catch_warnings(record=True) as w:
+        client = Client("localhost", 5679)
+
+    assert len(w) == 1
+    assert "optional parameters" in str(w[0].message)
+    assert not client.allow_unknown_opt_params

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -1,5 +1,7 @@
-from smpplib import consts
+from smpplib import consts, exceptions
 from smpplib.command import DeliverSM
+
+import pytest
 
 
 def test_parse_deliver_sm():
@@ -21,3 +23,24 @@ def test_parse_deliver_sm():
     assert pdu.source_network_type == consts.SMPP_NETWORK_TYPE_GSM
     assert pdu.message_state == consts.SMPP_MESSAGE_STATE_DELIVERED
     assert pdu.user_message_reference is None
+
+
+def test_unrecognised_optional_parameters():
+    pdu = DeliverSM("deliver_sm", allow_unknown_opt_params=True)
+    pdu.parse(b'\x00\x00\x00\xa8\x00\x00\x00\x05\x00\x00\x00\x00/p\xc6'
+              b'\x9a\x00\x00\x0022549909028\x00\x01\x00\x00\x04\x00\x00'
+              b'\x00\x00\x00\x00\x00\x00iid:795920026 sub:001 dlvrd:001 '
+              b'submit date:200319131913 done date:200319131913 stat:DELIVRD err:000 text:'
+              b'\x14\x03\x00\x07(null)\x00\x14\x02\x00\x04612\x00'
+    )
+
+    # This is only to avoid a breaking change, at some point the other behaviour
+    # should become the default.
+    with pytest.raises(exceptions.UnknownCommandError):
+        pdu2 = DeliverSM("deliver_sm")
+        pdu2.parse(b'\x00\x00\x00\xa8\x00\x00\x00\x05\x00\x00\x00\x00/p\xc6'
+                  b'\x9a\x00\x00\x0022549909028\x00\x01\x00\x00\x04\x00\x00'
+                  b'\x00\x00\x00\x00\x00\x00iid:795920026 sub:001 dlvrd:001 '
+                  b'submit date:200319131913 done date:200319131913 stat:DELIVRD err:000 text:'
+                  b'\x14\x03\x00\x07(null)\x00\x14\x02\x00\x04612\x00'
+        )


### PR DESCRIPTION
See page 43 of https://smpp.org/SMPP_v3_4_Issue1_2.pdf for details on why.

This adds a new flag `allow_unknown_opt_params` to the client which is passed down to the PDU parsing code to control if unknown optional parameters are allowed. The default behaviour is unchanged to avoid a breaking change, but the example code in the readme has been updated to use the new setting.

Fixes #111 