### PR TITLE
The max check should include the NULL terminator.

### DIFF
--- a/smpplib/command.py
+++ b/smpplib/command.py
@@ -171,7 +171,7 @@ class Command(pdu.PDU):
             size = self.params[field].size
             value = field_value.ljust(size, chr(0))
         elif hasattr(self.params[field], 'max'):
-            if len(field_value or '') > self.params[field].max:
+            if len(field_value or '') >= self.params[field].max:
                 field_value = field_value[0:self.params[field].max - 1]
 
             if field_value:


### PR DESCRIPTION
I noticed odd behavior when I specified a password with 9 characters (SMPP spec limit to 8 chars and NULL terminator). 

It seems like the max check was off by 1, and so it was passing a 9 byte password and 1 NULL for a total of 10 octets.

e.g with the following inputs:
password works
password1 fails with bind password error from downstream smsc (smppsim in this case).
password12 works (get truncated to 8 chars).