### PR TITLE
Fixing pdu.generate() encoding

### DIFF
--- a/smpplib/command.py
+++ b/smpplib/command.py
@@ -177,11 +177,19 @@ class Command(pdu.PDU):
                 field_value = field_value[0:self.params[field].max - 1]
 
             if field_value:
-                value = field_value + chr(0)
+                if not isinstance(field_value, bytes):
+                    value = field_value + chr(0)
+                else:
+                    value = field_value + chr(0).encode()
             else:
-                value = chr(0)
+                if not isinstance(field_value, bytes):
+                    value = chr(0)
+                else:
+                    value = chr(0).encode()
 
         setattr(self, field, field_value)
+        if isinstance(value, bytes):
+            return value
         return six.b(value)
 
     def _generate_ostring(self, field):


### PR DESCRIPTION
pdu.generate()
will lead to the following exception, so this is the proposed fix for it.
<pre>
      File "/opt/smpp_proxy_server/smpplib/pdu.py", line 136, in generate
        body = self.generate_params()
      File "/opt/smpp_proxy_server/smpplib/command.py", line 144, in generate_params
        value = self._generate_string(field)
      File "/opt/smpp_proxy_server/smpplib/command.py", line 180, in _generate_string
        value = field_value + chr(0)
    TypeError: can't concat str to bytes
</pre>