### PR TITLE
Remove end-of-life'd python versions from circleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,10 +8,7 @@ workflows:
       - test-3.7
       - test-3.6
       - test-3.5
-      - test-3.4
-      - test-2.7
       - test-pypy3
-      - test-pypy2
 jobs:
   test-3.9: &test-template
     docker:
@@ -52,19 +49,7 @@ jobs:
     <<: *test-template
     docker:
       - image: python:3.5-alpine
-  test-3.4:
-    <<: *test-template
-    docker:
-      - image: python:3.4-alpine
-  test-2.7:
-    <<: *test-template
-    docker:
-      - image: python:2.7-alpine
   test-pypy3:
     <<: *test-template
     docker:
       - image: pypy:3-slim
-  test-pypy2:
-    <<: *test-template
-    docker:
-      - image: pypy:2-slim


### PR DESCRIPTION
python 3.4 is causing the tests to fail, and it's EOL so I guess it's ok to
remove it?

python 2 - I'd like to try out adding type checking support and I think that's a
lot harder with python 2, so if it's ok I'd like to remove support.