### PR TITLE
Add mandatory parameters to GenericNack command

### DIFF
--- a/smpplib/command.py
+++ b/smpplib/command.py
@@ -567,6 +567,8 @@ class DataSMResp(Command):
 class GenericNAck(Command):
     """General Negative Acknowledgement class"""
 
+    params = {}
+    params_order = ()
     _defs = []
 
     def __init__(self, command, **kwargs):


### PR DESCRIPTION
The command can't currently be used because we try to iterate over a nonexistent params_order attribute: https://github.com/wavemm/python-smpplib/blob/9bccddc28927fba46eb5b752c62178427d917665/smpplib/command.py#L121