### PR TITLE
fix socket recv error being silently ignored

### DIFF
--- a/smpplib/client.py
+++ b/smpplib/client.py
@@ -256,7 +256,7 @@ class Client(object):
             except socket.error as e:
                 self.logger.warning(e)
                 raise exceptions.ConnectionError()
-            if not raw_pdu:
+            if not raw_pdu_part:
                 raise exceptions.ConnectionError()
             raw_pdu += raw_pdu_part
 


### PR DESCRIPTION
https://github.com/python-smpplib/python-smpplib/blob/4d74dc1edb4462136dff0f61dec79fe59c609609/smpplib/client.py#L259-L260

`raw_pdu` can never be "falsy" as it was already tested above:
https://github.com/python-smpplib/python-smpplib/blob/4d74dc1edb4462136dff0f61dec79fe59c609609/smpplib/client.py#L241-L242

So this if-condition is never satisfied and the socket recv error is silently passed. It could potentially corrupt further recvs.