### PR TITLE
increment sequence of commands as spec (fixes #214)

### DIFF
--- a/smpplib/command.py
+++ b/smpplib/command.py
@@ -410,7 +410,7 @@ class BindTransmitter(Command):
     )
 
     def __init__(self, command, **kwargs):
-        super(BindTransmitter, self).__init__(command, need_sequence=False, **kwargs)
+        super(BindTransmitter, self).__init__(command, need_sequence=True, **kwargs)
 
         self._set_vars(**(dict.fromkeys(self.params)))
         self.interface_version = consts.SMPP_VERSION_34
@@ -817,7 +817,7 @@ class DeliverSM(SubmitSM):
     )
 
     def __init__(self, command, **kwargs):
-        super(DeliverSM, self).__init__(command, need_sequence=False, **kwargs)
+        super(DeliverSM, self).__init__(command, need_sequence=True, **kwargs)
         self._set_vars(**(dict.fromkeys(self.params)))
 
 
@@ -900,7 +900,7 @@ class Unbind(Command):
     params_order = ()
 
     def __init__(self, command, **kwargs):
-        super(Unbind, self).__init__(command, need_sequence=False, **kwargs)
+        super(Unbind, self).__init__(command, need_sequence=True, **kwargs)
 
 
 class UnbindResp(Command):
@@ -919,7 +919,7 @@ class EnquireLink(Command):
     params_order = ()
 
     def __init__(self, command, **kwargs):
-        super(EnquireLink, self).__init__(command, need_sequence=False, **kwargs)
+        super(EnquireLink, self).__init__(command, need_sequence=True, **kwargs)
 
 
 class EnquireLinkResp(Command):

--- a/smpplib/command.py
+++ b/smpplib/command.py
@@ -410,7 +410,7 @@ class BindTransmitter(Command):
     )
 
     def __init__(self, command, **kwargs):
-        super(BindTransmitter, self).__init__(command, need_sequence=True, **kwargs)
+        super(BindTransmitter, self).__init__(command, **kwargs)
 
         self._set_vars(**(dict.fromkeys(self.params)))
         self.interface_version = consts.SMPP_VERSION_34
@@ -817,7 +817,7 @@ class DeliverSM(SubmitSM):
     )
 
     def __init__(self, command, **kwargs):
-        super(DeliverSM, self).__init__(command, need_sequence=True, **kwargs)
+        super(DeliverSM, self).__init__(command, **kwargs)
         self._set_vars(**(dict.fromkeys(self.params)))
 
 
@@ -900,7 +900,7 @@ class Unbind(Command):
     params_order = ()
 
     def __init__(self, command, **kwargs):
-        super(Unbind, self).__init__(command, need_sequence=True, **kwargs)
+        super(Unbind, self).__init__(command, **kwargs)
 
 
 class UnbindResp(Command):
@@ -919,7 +919,7 @@ class EnquireLink(Command):
     params_order = ()
 
     def __init__(self, command, **kwargs):
-        super(EnquireLink, self).__init__(command, need_sequence=True, **kwargs)
+        super(EnquireLink, self).__init__(command, **kwargs)
 
 
 class EnquireLinkResp(Command):

--- a/smpplib/tests/test_command.py
+++ b/smpplib/tests/test_command.py
@@ -1,11 +1,13 @@
 from smpplib import consts, exceptions
+from smpplib.client import Client
 from smpplib.command import DeliverSM
 
 import pytest
 
 
 def test_parse_deliver_sm():
-    pdu = DeliverSM('deliver_sm')
+    client = Client("localhost", 5679)
+    pdu = DeliverSM('deliver_sm', client=client)
     pdu.parse(
         b"\x00\x00\x00\xcb\x00\x00\x00\x05\x00\x00\x00\x00\x00\x00\x00\x01\x00"
         b"\x01\x0131600000000\x00\x05\x00XXX YYYY\x00\x04\x00\x00\x00\x00\x00"
@@ -26,7 +28,8 @@ def test_parse_deliver_sm():
 
 
 def test_unrecognised_optional_parameters():
-    pdu = DeliverSM("deliver_sm", allow_unknown_opt_params=True)
+    client = Client("localhost", 5679)
+    pdu = DeliverSM("deliver_sm", client=client, allow_unknown_opt_params=True)
     pdu.parse(b'\x00\x00\x00\xa8\x00\x00\x00\x05\x00\x00\x00\x00/p\xc6'
               b'\x9a\x00\x00\x0022549909028\x00\x01\x00\x00\x04\x00\x00'
               b'\x00\x00\x00\x00\x00\x00iid:795920026 sub:001 dlvrd:001 '
@@ -37,7 +40,7 @@ def test_unrecognised_optional_parameters():
     # This is only to avoid a breaking change, at some point the other behaviour
     # should become the default.
     with pytest.raises(exceptions.UnknownCommandError):
-        pdu2 = DeliverSM("deliver_sm")
+        pdu2 = DeliverSM("deliver_sm", client=client)
         pdu2.parse(b'\x00\x00\x00\xa8\x00\x00\x00\x05\x00\x00\x00\x00/p\xc6'
                   b'\x9a\x00\x00\x0022549909028\x00\x01\x00\x00\x04\x00\x00'
                   b'\x00\x00\x00\x00\x00\x00iid:795920026 sub:001 dlvrd:001 '


### PR DESCRIPTION
fixes [#214](https://github.com/python-smpplib/python-smpplib/issues/214)

made need_sequence=True for the following commands:
- BindTransmitter
- BindReceiver
- BindTransceiver
- Unbind
- DeliverySM
- EnquireLink