### PR TITLE
Add next_sequnce method for default_client

### DIFF
--- a/smpplib/pdu.py
+++ b/smpplib/pdu.py
@@ -36,6 +36,11 @@ class default_client(object):
     """Dummy client"""
     sequence = 0
 
+    def next_sequence(self):
+        current_sequence = self.sequence
+        self.sequence += 1
+        return current_sequence
+
 
 class PDU(object):
     """PDU class"""


### PR DESCRIPTION
After https://github.com/python-smpplib/python-smpplib/commit/df9c9dbdcebc585bbfcc6e960175298730b29955 PDU can not be created without client, because it uses default_client instead

To reproduce

```
from smpplib import smpp


server_packet = smpp.make_pdu('deliver_sm', source_addr='78005553535', short_message=b'test').generate()
```