### PR TITLE
Update command.py to fix max string error

### DIFF
--- a/smpplib/command.py
+++ b/smpplib/command.py
@@ -171,7 +171,7 @@ class Command(pdu.PDU):
             value = field_value.ljust(size, chr(0))
         elif hasattr(self.params[field], 'max'):
             if len(field_value or '') >= self.params[field].max:
-                field_value = field_value[0:self.params[field].max - 1]
+                field_value = field_value[0:self.params[field].max]
 
             if field_value:
                 value = field_value + chr(0)
@@ -213,7 +213,7 @@ class Command(pdu.PDU):
             value = struct.pack(">HH", field_code, size) + fvalue
         elif hasattr(self.params[field], 'max'):
             if len(field_value or '') > self.params[field].max:
-                field_value = field_value[0:self.params[field].max - 1]
+                field_value = field_value[0:self.params[field].max]
 
             if field_value:
                 fvalue = field_value + chr(0)


### PR DESCRIPTION
Current code use `[0:max - 1]` to trim string. However, when create substring by `[START:END]` python don't include `END`'s charactrer in the return string. 

So, current code that specific `max = 9` will retrun 8 charactors. This commit fix this issue.  

Also, recheck with SMPPv34 spec ([pdf at page 46](https://smpp.org/SMPP_v3_4_Issue1_2.pdf)), it memtion password is `var.max 9` that mean it should support string of 9 charactors.
![image](https://github.com/python-smpplib/python-smpplib/assets/92186/5fd90f59-a69a-4571-ae08-ab5e792dc4dc)
