### PR TITLE
Do not create socket on __init__

### DIFF
--- a/smpplib/client.py
+++ b/smpplib/client.py
@@ -92,7 +92,7 @@ class Client(object):
             self.allow_unknown_opt_params = allow_unknown_opt_params
 
 
-        self._socket = self._create_socket()
+        self._socket = None
 
     def __enter__(self):
         return self


### PR DESCRIPTION
I don't think it is ok to create the socket outside of connect() when the only way to close it is in disconnect(). It leads to unnecessary warnings on object destruction.